### PR TITLE
refactor: replace package globals with Config struct

### DIFF
--- a/.agents/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.agents/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms ([LANGUAGE.md](LANGUAGE.md)) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from [LANGUAGE.md](LANGUAGE.md). Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.agents/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, the same template as before, but rendered as a card:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/gmailauth.go
+++ b/gmailauth.go
@@ -17,18 +17,18 @@ import (
 )
 
 // getClient retrieves a token and returns an OAuth2 HTTP client.
-func getClient(ctx context.Context, config *oauth2.Config) *http.Client {
-	ts := getTokenSource(ctx, config)
+func getClient(ctx context.Context, config *oauth2.Config, oauthPort int) *http.Client {
+	ts := getTokenSource(ctx, config, oauthPort)
 	return oauth2.NewClient(ctx, ts)
 }
 
 // getTokenSource retrieves a saved token (or obtains a new one from the web)
 // and returns a TokenSource that auto-refreshes.
-func getTokenSource(ctx context.Context, config *oauth2.Config) oauth2.TokenSource {
+func getTokenSource(ctx context.Context, config *oauth2.Config, oauthPort int) oauth2.TokenSource {
 	tokFile := "token.json"
 	tok, err := tokenFromFile(tokFile)
 	if err != nil {
-		tok = getTokenFromWeb(ctx, config)
+		tok = getTokenFromWeb(ctx, config, oauthPort)
 		saveToken(tokFile, tok)
 	}
 
@@ -38,7 +38,7 @@ func getTokenSource(ctx context.Context, config *oauth2.Config) oauth2.TokenSour
 }
 
 // Request a token from the web, then returns the retrieved token.
-func getTokenFromWeb(ctx context.Context, config *oauth2.Config) *oauth2.Token {
+func getTokenFromWeb(ctx context.Context, config *oauth2.Config, oauthPort int) *oauth2.Token {
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 	fmt.Printf("Go to the following link in your browser then type the "+
 		"authorization code: \n%v\n", authURL)

--- a/main.go
+++ b/main.go
@@ -21,15 +21,16 @@ import (
 	"google.golang.org/api/option"
 )
 
-var timeout int
-var initialDelay int
-var days int
-var debug bool
-var concurrency int
-var oauthPort int
-var cutoffDate string
+type Config struct {
+	Timeout      int
+	InitialDelay int
+	Days         int
+	Debug        bool
+	Concurrency  int
+	OAuthPort    int
+}
 
-func loadConfig() error {
+func loadConfig() (*Config, error) {
 	pflag.Int("timeout", 60, "timeout in seconds")
 	pflag.Int("initial-delay", 1000, "max initial delay in milliseconds before starting to fetch messages")
 	pflag.Int("days", 30, "number of days to look back")
@@ -43,40 +44,32 @@ func loadConfig() error {
 	viper.AutomaticEnv()
 
 	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		return fmt.Errorf("failed to bind flags: %w", err)
+		return nil, fmt.Errorf("failed to bind flags: %w", err)
 	}
 
-	timeout = viper.GetInt("timeout")
-	initialDelay = viper.GetInt("initial-delay")
-	days = viper.GetInt("days")
-	debug = viper.GetBool("debug")
-	concurrency = viper.GetInt("concurrency")
-	oauthPort = viper.GetInt("oauth-port")
-
-	return nil
+	return &Config{
+		Timeout:      viper.GetInt("timeout"),
+		InitialDelay: viper.GetInt("initial-delay"),
+		Days:         viper.GetInt("days"),
+		Debug:        viper.GetBool("debug"),
+		Concurrency:  viper.GetInt("concurrency"),
+		OAuthPort:    viper.GetInt("oauth-port"),
+	}, nil
 }
 
-func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, error) {
+func listSpamMessages(ctx context.Context, srv *gmail.Service, cfg *Config, cutoffDate string) (map[string]int, error) {
 	dailyCounts := make(map[string]int)
 	pageToken := ""
 
-	// We'll collect full messages into `messages` but fetch them using a
-	// bounded worker pool to avoid launching an unbounded number of
-	// goroutines. Use errgroup for easier error handling.
-
-	// Calculate the date 'days' ago
-	query := "after:" + cutoffDate // Gmail query to filter messages
+	query := "after:" + cutoffDate
 	fmt.Printf("Gmail query: %s\n", query)
 	total := 0
 	failedFetches := 0
 
-	// Use a cancellable context with timeout so the whole listing/fetching
-	// process respects the -timeout flag.
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.Timeout)*time.Second)
 	defer cancel()
 
-	// Bounded concurrency for fetching full messages
-	maxWorkers := concurrency
+	maxWorkers := cfg.Concurrency
 	if maxWorkers <= 0 {
 		maxWorkers = 1
 	}
@@ -92,8 +85,6 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 		}
 
 		var listResp *gmail.ListMessagesResponse
-		// Wrap the request with a context check so we exit quickly if the
-		// parent context is cancelled.
 		if err := retryWithBackoff(ctx, func() error {
 			select {
 			case <-ctx.Done():
@@ -102,7 +93,7 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 			}
 			var err error
 			listResp, err = req.Do()
-			if err != nil && debug {
+			if err != nil && cfg.Debug {
 				log.Printf("Error fetching messages list: %v", err)
 			}
 			return err
@@ -110,7 +101,6 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 			return nil, fmt.Errorf("error fetching messages: %v", err)
 		}
 
-		// Process messages with bounded concurrency
 		for _, msg := range listResp.Messages {
 			m := msg
 			total++
@@ -120,8 +110,7 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 			eg.Go(func() error {
 				defer func() { <-sem }()
 
-				// delay a random interval between 0 and initialDelay milliseconds to avoid hitting rate limits
-				time.Sleep(time.Duration(rand.Intn(initialDelay)) * time.Millisecond)
+				time.Sleep(time.Duration(rand.Intn(cfg.InitialDelay)) * time.Millisecond)
 
 				var fullMsg *gmail.Message
 				if err := retryWithBackoff(ctx, func() error {
@@ -132,7 +121,7 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 					}
 					var err error
 					fullMsg, err = srv.Users.Messages.Get("me", m.Id).Format("minimal").Do()
-					if err != nil && debug {
+					if err != nil && cfg.Debug {
 						log.Printf("Error fetching message %s: %v", m.Id, err)
 					}
 					return err
@@ -140,21 +129,19 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 					mu.Lock()
 					failedFetches++
 					mu.Unlock()
-					if debug {
+					if cfg.Debug {
 						log.Printf("Failed to fetch message %s: %v", m.Id, err)
 					}
-					return nil // non-fatal; continue with other messages
+					return nil
 				}
 
 				if fullMsg != nil {
-					// internalDate is milliseconds since epoch
-					internalDateMs := fullMsg.InternalDate
-					if emailDate := internalDateToDate(internalDateMs); emailDate != "" {
+					if emailDate := internalDateToDate(fullMsg.InternalDate); emailDate != "" {
 						mu.Lock()
 						dailyCounts[emailDate]++
 						mu.Unlock()
-					} else if debug {
-						log.Printf("Warning: Invalid internalDate (%d) for message ID %s", internalDateMs, fullMsg.Id)
+					} else if cfg.Debug {
+						log.Printf("Warning: Invalid internalDate (%d) for message ID %s", fullMsg.InternalDate, fullMsg.Id)
 					}
 				}
 				return nil
@@ -167,9 +154,8 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 		}
 	}
 
-	fmt.Print("\r") // erase the in progress count
+	fmt.Print("\r")
 
-	// Wait for all workers to finish (or context timeout)
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
@@ -181,14 +167,13 @@ func listSpamMessages(ctx context.Context, srv *gmail.Service) (map[string]int, 
 	return dailyCounts, nil
 }
 
-func printSpamSummary(spamCounts map[string]int) {
+func printSpamSummary(spamCounts map[string]int, cutoffDate string) {
 	cutoff, err := time.Parse("2006-01-02", cutoffDate)
 	if err != nil {
 		log.Printf("Error parsing cutoff date: %v", err)
 		return
 	}
 
-	// Split dates into before and after cutoff.
 	var before, after []string
 	for date := range spamCounts {
 		dateValue, err := time.Parse("2006-01-02", date)
@@ -225,33 +210,31 @@ func printSpamSummary(spamCounts map[string]int) {
 }
 
 func main() {
-	if err := loadConfig(); err != nil {
+	cfg, err := loadConfig()
+	if err != nil {
 		log.Fatalf("Unable to load configuration: %v", err)
 	}
-	cutoffDate = time.Now().AddDate(0, 0, -days).Format("2006-01-02")
-
-	// The global random number generator is automatically seeded in Go 1.20+.
+	cutoffDate := time.Now().AddDate(0, 0, -cfg.Days).Format("2006-01-02")
 
 	ctx := context.Background()
-	b, err := os.ReadFile("credentials.json") // Download from Google Cloud Console
+	b, err := os.ReadFile("credentials.json")
 	if err != nil {
 		log.Fatalf("Unable to read client secret file: %v", err)
 	}
 
-	// If modifying these scopes, delete your previously saved token.json.
 	config, err := google.ConfigFromJSON(b, gmail.GmailReadonlyScope)
 	if err != nil {
 		log.Fatalf("Unable to parse client secret file to config: %v", err)
 	}
-	config.RedirectURL = fmt.Sprintf("http://127.0.0.1:%d", oauthPort)
-	client := getClient(ctx, config)
+	config.RedirectURL = fmt.Sprintf("http://127.0.0.1:%d", cfg.OAuthPort)
+	client := getClient(ctx, config, cfg.OAuthPort)
 
 	srv, err := gmail.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		log.Fatalf("Unable to retrieve Gmail client: %v", err)
 	}
 
-	spamCounts, err := listSpamMessages(ctx, srv)
+	spamCounts, err := listSpamMessages(ctx, srv, cfg, cutoffDate)
 	if err != nil {
 		log.Fatalf("Unable to list spam messages: %v", err)
 	}
@@ -261,8 +244,8 @@ func main() {
 		return
 	}
 
-	fmt.Printf("Spam email counts for the past %v days (based on internalDate):\n", days)
-	printSpamSummary(spamCounts)
+	fmt.Printf("Spam email counts for the past %v days (based on internalDate):\n", cfg.Days)
+	printSpamSummary(spamCounts, cutoffDate)
 }
 
 // retryWithBackoff retries the provided operation with exponential backoff
@@ -305,7 +288,7 @@ func isNonRetryable(err error) bool {
 		code := apiErr.Code
 		return code != 429 && code >= 400 && code < 500
 	}
-	return false // non-API errors (network, etc.) are retryable
+	return false
 }
 
 // internalDateToDate converts gmail InternalDate (ms since epoch) to a

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Introduced a `Config` struct to hold all CLI/env configuration, replacing 7 package-level global variables
- `loadConfig()` now returns `(*Config, error)` instead of writing to globals
- `listSpamMessages` and `printSpamSummary` accept `cfg *Config` and `cutoffDate string` as explicit parameters
- `getClient`, `getTokenSource`, and `getTokenFromWeb` in `gmailauth.go` now accept `oauthPort int` as a parameter, eliminating the hidden cross-file dependency on the global

## Why

Package-level globals create implicit coupling between files and make functions hard to test in isolation. `oauthPort` in particular was a silent dependency from `gmailauth.go` into `main.go`'s global scope. Passing config explicitly makes the data flow visible and the code easier to reason about.

## Reviewer notes

No behavior changes — only the data flow is restructured. All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)